### PR TITLE
feat: Add option to toggle fetching gist code

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,5 @@
 {
-    "display_format": "table"
+    "display_format": "table",
+    "fetch_gist_code": false
 }
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -43,11 +43,13 @@ To run this repository on your own GitHub profile, please [fork it](https://gith
 
 ## Configuration
 
-You can choose to display the gists in a table or list format. To change the display format, update the `config.json` file in the root of the repository.
+You can choose to display the gists in a table or list format and decide whether to fetch and store the gists code locally or not.
+To configure these options, update the `config.json` file in the root of the repository.
 
 ```json
 {
-    "display_format": "table"  // or "list"
+    "display_format": "table",  // or "list"
+    "fetch_gist_code": true      // or false
 }
 ```
 

--- a/scripts/update_gists.py
+++ b/scripts/update_gists.py
@@ -43,7 +43,8 @@ def main() -> None:
         logging.info("Creating gists directories and files...")
         for gist in sorted_gists:
             folder_name = create_gist_index(gist)
-            save_gist_files(gist, folder_name)
+            if config["fetch_gist_code"] is True:
+                save_gist_files(gist, folder_name)
             logging.info(f"Processed gist: {folder_name}")
 
         logging.info("Updating README...")


### PR DESCRIPTION
### Pull Request

**Description:**
This pull request introduces a new feature that allows users to toggle the fetching and saving of gist code through the fetch_gist_code option in the config.json file. The update_gists.py script has been updated to conditionally save gist files based on this configuration. Documentation has been updated in SETUP.md to reflect these changes.

**Related Issues:**
Closes #19

**Checklist:**
- [x] Ensure any install or build dependencies are removed before the end of the layer when doing a build.
- [x] Update the documentation with details of changes to the interface, this includes new environment variables, useful file locations, and container parameters.
- [x] Ensure that your code conforms to existing code conventions and test coverage.
- [x] Ensure your feature or fix passes all tests.
- [x] Make sure your commit messages are clear and appropriate.

**Steps to Test:**

1. Update `config.json` and set `fetch_gist_code` to `true`.
2. Run the `update_gists.py` script and verify that the gist code is fetched and saved.
3. Set `fetch_gist_code` to `false` and rerun the script to ensure gist code is not fetched.

**Screenshots (if applicable):**
Not applicable

**Additional Context:**
This feature provides flexibility for users who may not want to store the gist code locally, optimising the process according to their needs.